### PR TITLE
Tune turret constants for turret A and add motion profile logging

### DIFF
--- a/src/main/java/frc/robot/subsystems/turret/Turret.java
+++ b/src/main/java/frc/robot/subsystems/turret/Turret.java
@@ -52,6 +52,7 @@ public class Turret extends SubsystemBase {
   private StatusSignal<Current> statorCurrentSignal;
   private StatusSignal<Current> supplyCurrentSignal;
   private StatusSignal<Boolean> hallSensorTriggeredSignal;
+  private StatusSignal<Double> profilePositionSignal;
 
   /** The simulation object that simulates the turret's behavior */
   private TurretSim simulation;
@@ -119,6 +120,7 @@ public class Turret extends SubsystemBase {
     statorCurrentSignal = motor.getStatorCurrent();
     supplyCurrentSignal = motor.getSupplyCurrent();
     hallSensorTriggeredSignal = candi.getS2Closed();
+    profilePositionSignal = motor.getClosedLoopReference();
 
     // Tunable angle input, PID values, Motion Magic constraints
     DogLog.tunable(
@@ -203,7 +205,8 @@ public class Turret extends SubsystemBase {
         voltageSignal,
         statorCurrentSignal,
         supplyCurrentSignal,
-        hallSensorTriggeredSignal);
+        hallSensorTriggeredSignal,
+        profilePositionSignal);
 
     // Check hall effect sensor and handle zeroing
     updateTurretAbsolutePosition();
@@ -217,6 +220,10 @@ public class Turret extends SubsystemBase {
     DogLog.log("Turret/SupplyCurrent", getSupplyCurrent());
     DogLog.log("Turret/HallSensorTriggered", isHallSensorTriggered());
     DogLog.log("Turret/IsZeroed", isZeroed());
+    DogLog.log(
+        "Turret/ProfilePosition",
+        Rotations.of(profilePositionSignal.getValue()).in(Radians),
+        Radians);
 
     LoggingUtil.log("Turret/ControlRequest", motor.getAppliedControl());
   }

--- a/src/main/java/frc/robot/subsystems/turret/TurretConstants.java
+++ b/src/main/java/frc/robot/subsystems/turret/TurretConstants.java
@@ -17,15 +17,15 @@ public class TurretConstants {
   public static final String CAN_BUS_NAME = "subsystems";
 
   // PID constants
-  public static final double kP = 1.5;
-  public static final double kD = 0.025;
-  public static final double kS = 0.155;
-  public static final double kV = 3.371;
-  public static final double kA = 0.0;
+  public static final double kP = 150.0;
+  public static final double kD = 5.0;
+  public static final double kS = 0.315;
+  public static final double kV = 4.283;
+  public static final double kA = 0.2;
 
   // Motion Magic constants
-  public static final double MOTION_MAGIC_CRUISE_VELOCITY = 1.0;
-  public static final double MOTION_MAGIC_ACCELERATION = 1.0;
+  public static final double MOTION_MAGIC_CRUISE_VELOCITY = 10.0;
+  public static final double MOTION_MAGIC_ACCELERATION = 10.0;
 
   // Current limits
   public static final Current STATOR_CURRENT_LIMIT = Amps.of(60);
@@ -56,7 +56,7 @@ public class TurretConstants {
    * turret passes through the sensor moving from lower to higher angles. Set to null to disable
    * zeroing when moving in this direction.
    */
-  public static final Angle MAXIMUM_HALL_SENSOR_TRIGGER_ANGLE = Radians.of(-0.831418);
+  public static final Angle MAXIMUM_HALL_SENSOR_TRIGGER_ANGLE = Radians.of(-0.664565);
 
   /**
    * The moment of inertia of the turret. This is used only for simulation and is not used in the
@@ -68,11 +68,11 @@ public class TurretConstants {
    * The minimum angle that the turret can be at. This is used to prevent the turret from trying to
    * move beyond its physical limits.
    */
-  public static final Angle MIN_ANGLE = Degrees.of(0);
+  public static final Angle MIN_ANGLE = Degrees.of(-276);
 
   /**
    * The maximum angle that the turret can be at. This is used to prevent the turret from trying to
    * move beyond its physical limits.
    */
-  public static final Angle MAX_ANGLE = Degrees.of(400);
+  public static final Angle MAX_ANGLE = Degrees.of(23);
 }


### PR DESCRIPTION
* Tune turret control constants (P, D, S, V, A, and trapezoidal profile constraints) for turret A.
* Add logging of the expected position based on the motion profile, which can be used to determine whether the profile is being successfully followed.